### PR TITLE
Add support for expanding indirect markdown reference links and applying multiple functions with `FileProcessor.map`

### DIFF
--- a/docs/reflinks.jl
+++ b/docs/reflinks.jl
@@ -2,4 +2,5 @@ reflinks = Dict(
     "[DocExtensions.jl]" => "https://github.com/omlins/DocExtensions.jl",
     "[Documenter.jl]"    => "https://github.com/JuliaDocs/Documenter.jl",
     "[Literate.jl]"      => "https://github.com/fredrikekre/Literate.jl",
+    "[Julia REPL]"       => "https://docs.julialang.org/en/v1/stdlib/REPL/",
 )

--- a/docs/src/api.MD
+++ b/docs/src/api.MD
@@ -25,7 +25,7 @@ Modules = [DocExtensions.MarkdownExtensions]
 Filter = t -> typeof(t) !== DocExtensions.MarkdownExtensions
 ```
 
-## Selective extensions to [Documenter.jl]
+## Extensions to [Documenter.jl]
 ```@docs
 DocExtensions.DocumenterExtensions
 ```

--- a/docs/src/api.MD
+++ b/docs/src/api.MD
@@ -4,6 +4,13 @@ CurrentModule = DocExtensions
 
 # API reference
 
+This is the offical API reference of `DocExtensions`. Note that it can also be queried interactively from the [Julia REPL] using the [help mode](https://docs.julialang.org/en/v1/stdlib/REPL/#Help-mode):
+```julia-repl
+julia> using DocExtensions
+julia>?
+help?> DocExtensions
+```
+
 ## Extensions to Markdown
 ```@docs
 DocExtensions.MarkdownExtensions
@@ -18,7 +25,7 @@ Modules = [DocExtensions.MarkdownExtensions]
 Filter = t -> typeof(t) !== DocExtensions.MarkdownExtensions
 ```
 
-## Specific punctual extensions to [Documenter.jl]
+## Selective extensions to [Documenter.jl]
 ```@docs
 DocExtensions.DocumenterExtensions
 ```

--- a/docs/src/index.MD
+++ b/docs/src/index.MD
@@ -1,5 +1,5 @@
 # [DocExtensions.jl] [![Star on GitHub](https://img.shields.io/github/stars/omlins/DocExtensions.jl.svg)](https://github.com/omlins/DocExtensions.jl/stargazers)
-The package `DocExtensions` provides selective extensions to documentation tools as [Documenter.jl] and [Literate.jl], as well as some generic extensions to Markdown. In addition, it includes a simple but generic file processor for pre- or post-processing of any kind of text files.
+The package `DocExtensions` provides small but well-directed extensions to documentation tools as [Documenter.jl] and [Literate.jl], as well as some generic extensions to Markdown. In addition, it includes a simple but generic file processor for pre- or post-processing of any kind of text files.
 
 ## Dependencies
 `DocExtensions` only relies on Julia standard packages.

--- a/docs/src/index.MD
+++ b/docs/src/index.MD
@@ -1,5 +1,5 @@
 # [DocExtensions.jl] [![Star on GitHub](https://img.shields.io/github/stars/omlins/DocExtensions.jl.svg)](https://github.com/omlins/DocExtensions.jl/stargazers)
-The package `DocExtensions` Provides specific punctual extensions to documentation tools as [Documenter.jl] and [Literate.jl], as well as some generic extensions to Markdown. In addition, it includes a simple but generic file processor for pre- or post-processing of any kind of text files.
+The package `DocExtensions` provides selective extensions to documentation tools as [Documenter.jl] and [Literate.jl], as well as some generic extensions to Markdown. In addition, it includes a simple but generic file processor for pre- or post-processing of any kind of text files.
 
 ## Dependencies
 `DocExtensions` only relies on Julia standard packages.

--- a/src/DocExtensions.jl
+++ b/src/DocExtensions.jl
@@ -1,7 +1,7 @@
 """
 Module DocExtensions
 
-Provides selective extensions to documentation tools as Documenter.jl and Literate.jl, as well as some generic extensions to Markdown. In addition, it includes a simple but generic file processor for pre- or post-processing of any kind of text files.
+Provides small but well-directed extensions to documentation tools as Documenter.jl and Literate.jl, as well as some generic extensions to Markdown. In addition, it includes a simple but generic file processor for pre- or post-processing of any kind of text files.
 """
 module DocExtensions
 

--- a/src/DocExtensions.jl
+++ b/src/DocExtensions.jl
@@ -1,7 +1,7 @@
 """
 Module DocExtensions
 
-Provides specific punctual extensions to documentation tools as Documenter.jl and Literate.jl, as well as some generic extensions to Markdown. In addition, it includes a simple but generic file processor for pre- or post-processing of any kind of text files.
+Provides selective extensions to documentation tools as Documenter.jl and Literate.jl, as well as some generic extensions to Markdown. In addition, it includes a simple but generic file processor for pre- or post-processing of any kind of text files.
 """
 module DocExtensions
 

--- a/src/DocumenterExtensions/DocumenterExtensions.jl
+++ b/src/DocumenterExtensions/DocumenterExtensions.jl
@@ -1,7 +1,7 @@
 """
 Module DocumenterExtensions
 
-Provides specific punctual extensions to Documenter.jl.
+Provides selective extensions to Documenter.jl.
 """
 module DocumenterExtensions
 

--- a/src/DocumenterExtensions/DocumenterExtensions.jl
+++ b/src/DocumenterExtensions/DocumenterExtensions.jl
@@ -1,7 +1,7 @@
 """
 Module DocumenterExtensions
 
-Provides selective extensions to Documenter.jl.
+Provides small but well-directed extensions to Documenter.jl.
 """
 module DocumenterExtensions
 

--- a/src/FileProcessor/map.jl
+++ b/src/FileProcessor/map.jl
@@ -1,21 +1,22 @@
 """
-    map(f, filepattern, args...; outfilepattern=filepattern, rootdir=".")
+    map(filepattern, f, args...; outfilepattern=filepattern, rootdir=".")
+    map(filepattern, (f, args)...; outfilepattern=filepattern, rootdir=".")
 
-Transform the file or collection of files in directory `rootdir` defined by `filepattern` by applying `f` to content of each file (calling `f(content, args...)`), writing the result back to the file(s) specified with `outfilepattern`; for both `filepattern` and `outfilepattern` currently supported is a file name extension (e.g. filepattern = `".MD"` and outfilepattern = `".md"`) or simply an explicit file name. The results of the file content transformation is also returned as a Vector of Strings.
+Transform the file or collection of files in directory `rootdir` defined by `filepattern` by applying `f` to content of each file (calling `f(content, args...)`), writing the result back to the file(s) specified with `outfilepattern`. The results of the file content transformation is also returned as a Vector of Strings. To apply multiple functions to the content of each file, a series of tuples of the kind `(f, args...)` can be passed instead of `f, args...`.
 
 ## Arguments
 - `f::Function`: the function to be applied to the content of the files.
-- `filepattern::AbstractString=".MD"`: a file extension or file name defining the files to be processed.
+- `filepattern::AbstractString: a file extension or file name defining the files to be processed.
 - `args...`: arguments to be passed to `f` in addition to the content of each file.
 
 ## Keyword Arguments
-- `outfilepattern::AbstractString=".MD"`: a file extension or file name defining the name(s) of the output files.
+- `outfilepattern::AbstractString=filepattern`: a file extension or file name defining the name(s) of the output files.
 - `rootdir::AbstractString="."`: the root directory of the files to be processed.
 - `do_write::Bool=true`:: whether to actually write the results into file(s).
 
 # Example
 ```julia
-docsrc             = joinpath(@_DIR_, "src")
+docsrc             = joinpath(@__DIR__, "src")
 file_extension     = ".MD"
 new_file_extension = ".md"
 reflinks           = Dict("[Adapt.jl]"        => "https://github.com/JuliaGPU/Adapt.jl",
@@ -29,17 +30,23 @@ escape(s)      = "\\Q" * escape_string(s) * "\\E"
 pattern        = Regex("(" * join(escape.(keys(reflinks)), "|") * ")(?![(].*[)])")
 replace_str(x) = "\$x(\$(reflinks[x]))"
 
-FileProcessor.map(replace, file_extension, pattern => replace_str; outfilepattern=new_file_extension, rootdir="src")
+FileProcessor.map(file_extension, replace, pattern => replace_str; outfilepattern=new_file_extension, rootdir="src")
 ```
 """
-function map(f::Function, filepattern::AbstractString, args...; outfilepattern::AbstractString=filepattern, rootdir::AbstractString=".", do_write::Bool=true)
+function map(filepattern::AbstractString, f::Function, args...; outfilepattern::AbstractString=filepattern, rootdir::AbstractString=".", do_write::Bool=true)
+    map(filepattern, (f, args); outfilepattern=outfilepattern, rootdir=rootdir, do_write=do_write)
+end
+
+function map(filepattern::AbstractString, f_args_tuples::Tuple...; outfilepattern::AbstractString=filepattern, rootdir::AbstractString=".", do_write::Bool=true)
     results = String[]
     for (root, dirs, files) in walkdir(rootdir)
         @debug "DocExtensions: FileProcessor.map: Processing file(s) matching $filepattern in $root..."
         for file in filter(endswith(filepattern), files)
             filepath = joinpath(root, file)
             content  = read(filepath, String)
-            content  = replace(content, args...)
+            for (f, args) in f_args_tuples
+                content = f(content, args...)
+            end
             push!(results, content)
             if (do_write)
                 filepath = filepath[1:end-length(filepattern)] * outfilepattern

--- a/test/MarkdownExtensions/index.MD
+++ b/test/MarkdownExtensions/index.MD
@@ -1,5 +1,5 @@
 # [DocExtensions.jl] [![Star on GitHub](https://img.shields.io/github/stars/omlins/DocExtensions.jl.svg)](https://github.com/omlins/DocExtensions.jl/stargazers)
-The package `DocExtensions` provides selective extensions to documentation tools as [Documenter.jl] and [Literate.jl], as well as some generic extensions to Markdown. In addition, it includes a simple but generic file processor for pre- or post-processing of any kind of text files.
+The package `DocExtensions` provides small but well-directed extensions to documentation tools as [Documenter.jl] and [Literate.jl], as well as some generic extensions to Markdown. In addition, it includes a simple but generic file processor for pre- or post-processing of any kind of text files.
 
 The [Julia documenter package][Documenter.jl] and the [Julia literate programming package][Literate.jl] package...
 

--- a/test/MarkdownExtensions/index.MD
+++ b/test/MarkdownExtensions/index.MD
@@ -1,5 +1,7 @@
 # [DocExtensions.jl] [![Star on GitHub](https://img.shields.io/github/stars/omlins/DocExtensions.jl.svg)](https://github.com/omlins/DocExtensions.jl/stargazers)
 The package `DocExtensions` provides selective extensions to documentation tools as [Documenter.jl] and [Literate.jl], as well as some generic extensions to Markdown. In addition, it includes a simple but generic file processor for pre- or post-processing of any kind of text files.
 
+The [Julia documenter package][Documenter.jl] and the [Julia literate programming package][Literate.jl] package...
+
 ## Dependencies
 `DocExtensions` only relies on Julia standard packages.

--- a/test/MarkdownExtensions/index.MD
+++ b/test/MarkdownExtensions/index.MD
@@ -1,5 +1,5 @@
 # [DocExtensions.jl] [![Star on GitHub](https://img.shields.io/github/stars/omlins/DocExtensions.jl.svg)](https://github.com/omlins/DocExtensions.jl/stargazers)
-The package `DocExtensions` Provides specific punctual extensions to documentation tools as [Documenter.jl] and [Literate.jl], as well as some generic extensions to Markdown. In addition, it includes a simple but generic file processor for pre- or post-processing of any kind of text files.
+The package `DocExtensions` Provides selective extensions to documentation tools as [Documenter.jl] and [Literate.jl], as well as some generic extensions to Markdown. In addition, it includes a simple but generic file processor for pre- or post-processing of any kind of text files.
 
 ## Dependencies
 `DocExtensions` only relies on Julia standard packages.

--- a/test/MarkdownExtensions/index.MD
+++ b/test/MarkdownExtensions/index.MD
@@ -1,5 +1,5 @@
 # [DocExtensions.jl] [![Star on GitHub](https://img.shields.io/github/stars/omlins/DocExtensions.jl.svg)](https://github.com/omlins/DocExtensions.jl/stargazers)
-The package `DocExtensions` Provides selective extensions to documentation tools as [Documenter.jl] and [Literate.jl], as well as some generic extensions to Markdown. In addition, it includes a simple but generic file processor for pre- or post-processing of any kind of text files.
+The package `DocExtensions` provides selective extensions to documentation tools as [Documenter.jl] and [Literate.jl], as well as some generic extensions to Markdown. In addition, it includes a simple but generic file processor for pre- or post-processing of any kind of text files.
 
 ## Dependencies
 `DocExtensions` only relies on Julia standard packages.

--- a/test/MarkdownExtensions/index.md
+++ b/test/MarkdownExtensions/index.md
@@ -1,0 +1,7 @@
+# [DocExtensions.jl](https://github.com/omlins/DocExtensions.jl) [![Star on GitHub](https://img.shields.io/github/stars/omlins/DocExtensions.jl.svg)](https://github.com/omlins/DocExtensions.jl/stargazers)
+The package `DocExtensions` provides small but well-directed extensions to documentation tools as [Documenter.jl](https://github.com/JuliaDocs/Documenter.jl) and [Literate.jl](https://github.com/fredrikekre/Literate.jl), as well as some generic extensions to Markdown. In addition, it includes a simple but generic file processor for pre- or post-processing of any kind of text files.
+
+The [Julia documenter package](https://github.com/JuliaDocs/Documenter.jl) and the [Julia literate programming package](https://github.com/fredrikekre/Literate.jl) package...
+
+## Dependencies
+`DocExtensions` only relies on Julia standard packages.

--- a/test/MarkdownExtensions/index.md
+++ b/test/MarkdownExtensions/index.md
@@ -1,7 +1,0 @@
-# [DocExtensions.jl](https://github.com/omlins/DocExtensions.jl) [![Star on GitHub](https://img.shields.io/github/stars/omlins/DocExtensions.jl.svg)](https://github.com/omlins/DocExtensions.jl/stargazers)
-The package `DocExtensions` provides small but well-directed extensions to documentation tools as [Documenter.jl](https://github.com/JuliaDocs/Documenter.jl) and [Literate.jl](https://github.com/fredrikekre/Literate.jl), as well as some generic extensions to Markdown. In addition, it includes a simple but generic file processor for pre- or post-processing of any kind of text files.
-
-The [Julia documenter package](https://github.com/JuliaDocs/Documenter.jl) and the [Julia literate programming package](https://github.com/fredrikekre/Literate.jl) package...
-
-## Dependencies
-`DocExtensions` only relies on Julia standard packages.

--- a/test/MarkdownExtensions/test_expand_reflinks.jl
+++ b/test/MarkdownExtensions/test_expand_reflinks.jl
@@ -10,5 +10,7 @@ using DocExtensions
         @test occursin("[DocExtensions.jl](https://github.com/omlins/DocExtensions.jl)", content)
         @test occursin("[Documenter.jl](https://github.com/JuliaDocs/Documenter.jl)", content)
         @test occursin("[Literate.jl](https://github.com/fredrikekre/Literate.jl)", content)
+        @test occursin("[Julia documenter package](https://github.com/JuliaDocs/Documenter.jl)", content)
+        @test occursin("[Julia literate programming package](https://github.com/fredrikekre/Literate.jl)", content)
     end;
 end;


### PR DESCRIPTION
This PR add support for indirect markdown reference links as, e.g., `[the Julia GPU package][CUDA.jl]`, where an entry for `[CUDA.jl]` is expected in `reflinks`.
It also adds support for applying multiple functions with `FileProcessor.map`.